### PR TITLE
Actual prototype of AS input parameters construction starting from a netCDF4 file, going via Zarr

### DIFF
--- a/netcdf_to_zarr.py
+++ b/netcdf_to_zarr.py
@@ -59,18 +59,17 @@ def slice_offset_size(fileloc, varname, selection):
                                                  out=None, fields=None,
                                                  compute_data=compute_data)
 
-    # integrate it in the Zarr mechanism
-
-    print("Running the PCI wrapper integrated in Zarr.Array:")
-    print(f"Data selection {selection}")
     chunks, chunk_sel, PCI = chunk_info[0]
-    print(f"Chunks {chunks}, chunk selection "
-          f"{chunk_sel}, PCI {list(PCI)}\n")
 
     offsets = []
     sizes = []
     for offset, size, _ in list(PCI):
         offsets.append(offset)
         sizes.append(size)
+
+    print(f"Requested data selection (slices): {selection}")
+    print(f"Master chunks: {chunks}, chunks selection: "
+          f"{chunk_sel}, \nZarr PCI: {list(PCI)}\n")
+    print(f"Slices offsets: {offsets}, \nslices sizes: {sizes}")
 
     return ds, chunks, chunk_sel, offsets, sizes

--- a/netcdf_to_zarr.py
+++ b/netcdf_to_zarr.py
@@ -1,0 +1,76 @@
+import os
+import zarr
+
+from kerchunk.hdf import SingleHdf5ToZarr
+
+
+def extract_dict(strarg):
+    """Extract a dict from a string-formatted dict."""
+    # FIXME this is a bit silly
+    return_dict = dict()
+    if "shape" in strarg:
+        items = strarg.split('"shape"')
+        val = items[1].split(":")[1].strip()
+        val = val.split('"zarr_format"')[0].split(',')[0:3]
+        val = (int(val[0].lstrip('[').strip()),
+               int(val[1].strip()),
+               int(val[2].split("]")[0].strip()))
+        return_dict["shape"] = val
+    if "chunks" in strarg:
+        items = strarg.split('"compressor"')
+        val = items[0].split(":")[1].strip()
+        val = [v.strip() for v in val.split('\n')]
+        val = (int(val[1].split(',')[0]),
+               int(val[2].split(',')[0]),
+               int(val[3]))
+        return_dict["chunks"] = val
+
+    return return_dict
+
+
+def load_netcdf_zarr_generic(fileloc, varname):
+    """Pass a netCDF4 file to be shaped as Zarr file by kerchunk."""
+    ds = SingleHdf5ToZarr(fileloc).translate()
+    varkey = varname + '/.zarray'
+    if not varkey in ds['refs']:
+        varkey = 'data/.zarray'
+        chunks = extract_dict(ds['refs'][varkey])["chunks"]
+    chunks = extract_dict(ds['refs'][varkey])["shape"]
+
+    store, chunk_store = dict(), dict()
+    ref_ds = zarr.create(chunks, chunks=chunks, compressor=None,
+                         dtype='f8', order='C',
+                         store=store, chunk_store=chunk_store)
+
+    return ref_ds
+
+
+def slice_offset_size(fileloc, varname, selection):
+    """Return a Zarr Array slice offset and size via PartialChunkIterator."""
+    # toggle compute_data
+    # this turns on and off the actual data payload loading into Zarr store
+    compute_data = False
+
+    # load the Zarr image
+    ds = load_netcdf_zarr_generic(fileloc, varname)
+
+    data_selection, chunk_info = \
+        zarr.core.Array.get_orthogonal_selection(ds, selection,
+                                                 out=None, fields=None,
+                                                 compute_data=compute_data)
+
+    # integrate it in the Zarr mechanism
+
+    print("Running the PCI wrapper integrated in Zarr.Array:")
+    print(f"Data selection {selection}")
+    chunks, chunk_sel, PCI = chunk_info[0]
+    print(f"Chunks {chunks}, chunk selection "
+          f"{chunk_sel}, PCI {list(PCI)}\n")
+
+    offsets = []
+    sizes = []
+    for offset, size, _ in list(PCI):
+        offsets.append(offset)
+        sizes.append(size)
+
+    return ds, chunks, chunk_sel, offsets, sizes

--- a/netcdf_to_zarr.py
+++ b/netcdf_to_zarr.py
@@ -122,10 +122,21 @@ def slice_offset_size(fileloc, varname, selection):
     print(f"Slices offsets: {offsets}, \nslices sizes: {sizes}")
 
     chunks_dict = zarr_chunks_info(ds)
-    chunks_coords = chunks_dict.keys()
-    chunks_sizes = chunks_dict.values()
+    chunks_coords = list(chunks_dict.keys())
+    chunks_sizes = list(chunks_dict.values())
     print("Chunks keys (i, j, k):", chunks_coords)
     print("Chunks sizes:", chunks_sizes)
-    # print("Chunks offsets:", chunks_offsets)
+    
+    # select chunks in selection
+    selected_chunks = []
+    selected_chunk_sizes = []
+    for sl in selection:
+        chunk_idx = chunks_coords[sl]
+        selected_chunks.append(chunk_idx)
+        chunk_size = chunks_sizes[sl]
+        selected_chunk_sizes.append(chunk_size)
+
+    print("Chunks in selections:", selected_chunks)
+    print("Chunks sizes in selections:", selected_chunk_sizes)
 
     return ds, chunks, chunk_sel, offsets, sizes

--- a/test_harness.py
+++ b/test_harness.py
@@ -6,8 +6,7 @@ from netCDF4 import Dataset
 import numpy as np
 import zarr
 
-from zarr import core as zarrcore
-from PCI_wrapper import load_netcdf_zarr_generic
+import netcdf_to_zarr as nz
 
 
 class Active:
@@ -125,23 +124,11 @@ class TestActive(unittest.TestCase):
         """
         data_file = self.testfile
         varname = "test_bizarre"
-
-        # load without data payload and apply a selection
-        ds = load_netcdf_zarr_generic(data_file, varname)
         selection = (slice(0, 2, 1), slice(4, 6, 1), slice(7, 9, 1))
-        data_selection, chunk_info = \
-            zarrcore.Array.get_orthogonal_selection(ds, selection,
-                                                    out=None, fields=None,
-                                                    compute_data=False)
 
         # get slicing info
-        _, _, PCI = chunk_info[0]
-        PCI = list(PCI)
-        offsets = []
-        sizes = []
-        for offset, size, _ in PCI:
-            offsets.append(offset)
-            sizes.append(size)
+        ds, master_chunks, chunk_selection, offsets, sizes = \
+            nz.slice_offset_size(data_file, varname, selection)
 
         # sanity checks
         assert len(offsets) == 4

--- a/test_harness.py
+++ b/test_harness.py
@@ -105,6 +105,24 @@ class TestActive(unittest.TestCase):
         """ 
         Shows what we expect an active example test to achieve and provides "the right answer" 
         """
+        active = Active(self.testfile)
+        active._version = 0
+        var = active['data']
+        d = var[0:2,4:6,7:9]
+        nda = np.ndarray.flatten(d.data)
+        mean_result = np.mean(nda)
+        active.close()
+
+        active = Active(self.testfile)
+        active._version = 2
+        active.method='mean'
+        result2 = var['data'][0:2,4:6,7:9]
+        assert mean_result == result2
+
+    def test_zarr_hijack(self):
+        """ 
+        Test the hijacking of Zarr. 
+        """
         data_file = self.testfile
         varname = "test_bizarre"
 
@@ -135,13 +153,6 @@ class TestActive(unittest.TestCase):
         nda = np.ndarray.flatten(ds[:][0])
         mean_result = np.mean(nda)
         assert np.isnan(mean_result)  # has to be; no data passed
-
-        # the other side of active
-        # active = Active(self.testfile)
-        # active._version = 2
-        # active.method='mean'
-        # result2 = var['data'][0:2,4:6,7:9]
-        # assert mean_result == result2
 
 
 if __name__=="__main__":

--- a/test_harness.py
+++ b/test_harness.py
@@ -135,6 +135,7 @@ class TestActive(unittest.TestCase):
         assert len(sizes) == len(offsets)
         assert offsets == [47, 57, 147, 157]
         assert sizes == [2, 2, 2, 2]
+        assert chunk_selection == selection
 
         # compute a mean
         nda = np.ndarray.flatten(ds[:][0])

--- a/test_harness.py
+++ b/test_harness.py
@@ -127,7 +127,8 @@ class TestActive(unittest.TestCase):
         selection = (slice(0, 2, 1), slice(4, 6, 1), slice(7, 9, 1))
 
         # get slicing info
-        ds, master_chunks, chunk_selection, offsets, sizes = \
+        (ds, master_chunks, chunk_selection,
+         offsets, sizes, selected_chunks, selected_chunk_sizes) = \
             nz.slice_offset_size(data_file, varname, selection)
 
         # sanity checks
@@ -136,6 +137,11 @@ class TestActive(unittest.TestCase):
         assert len(sizes) == len(offsets)
         assert offsets == [1, 4]  # need to check the actual item size
         assert sizes == [2, 2]
+        assert selected_chunks == [[(0, 0, 0), (0, 0, 1)], 
+                                   [(0, 0, 4), (0, 0, 5)], 
+                                   [(0, 0, 7), (0, 0, 8)]]
+        assert selected_chunk_sizes == [[72, 72], [72, 72], [72, 72]]
+
 
         # compute a mean
         nda = np.ndarray.flatten(ds[:][0])

--- a/test_harness.py
+++ b/test_harness.py
@@ -131,16 +131,17 @@ class TestActive(unittest.TestCase):
             nz.slice_offset_size(data_file, varname, selection)
 
         # sanity checks
-        assert len(offsets) == 4
+        assert master_chunks == (3, 3, 1)
+        assert len(offsets) == 2
         assert len(sizes) == len(offsets)
-        assert offsets == [47, 57, 147, 157]
-        assert sizes == [2, 2, 2, 2]
-        assert chunk_selection == selection
+        assert offsets == [1, 4]  # need to check the actual item size
+        assert sizes == [2, 2]
 
         # compute a mean
         nda = np.ndarray.flatten(ds[:][0])
         mean_result = np.mean(nda)
-        assert np.isnan(mean_result)  # has to be; no data passed
+        print("Mean result", mean_result)
+        assert mean_result > 1.e100  # has mental data 1e300
 
 
 if __name__=="__main__":


### PR DESCRIPTION
So this isa a somewhat changed setup of the test that @bnlawrence wrote but this PR achies the following:

- allows for functionality to load a netCDF4 file into a Zarr metadata store object that can then be passed around inside Zarr (note: no data payload is loaded and given to Zarr); this is done with `kerchunk`, and is currently impressively ugly;
- sets up a workflow to obtain the `slice_coords: (offset, size)` of each needed slice directly from Zarr, while fooling Zarr that it doesn't need data, all it needs is data structure (chunks, data shape, data type etc) and love;
- added UnitTest for that - @bnlawrence will be sad I changed his :grin: 